### PR TITLE
Fix file leak when loading module configuration

### DIFF
--- a/module3rd/load.go
+++ b/module3rd/load.go
@@ -13,6 +13,7 @@ func Load(path string) ([]Module3rd, error) {
 		if err != nil {
 			return modules, err
 		}
+		defer f.Close()
 		if err := json.NewDecoder(f).Decode(&modules); err != nil {
 			return modules, fmt.Errorf("modulesConfPath(%s) is invalid JSON.", path)
 		}


### PR DESCRIPTION
## Summary
- close configuration file in module3rd.Load to avoid leaking file descriptors

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684d10f462948326bafaa44fbf2d920e