### PR TITLE
Refactor error handling and logging

### DIFF
--- a/builder/nginx.go
+++ b/builder/nginx.go
@@ -2,6 +2,8 @@ package builder
 
 import (
 	"bufio"
+	"fmt"
+	"log"
 	"os"
 	"strconv"
 
@@ -16,6 +18,7 @@ func BuildNginx(jobs int) error {
 
 	f, err := os.Create("nginx-build.log")
 	if err != nil {
+		log.Printf("[warn] could not create nginx-build.log: %v", err)
 		return command.Run(args)
 	}
 	defer f.Close()
@@ -28,7 +31,11 @@ func BuildNginx(jobs int) error {
 	cmd.Stderr = writer
 	defer writer.Flush()
 
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("make failed: %w", err)
+	}
+
+	return nil
 }
 
 func IsSameVersion(builders []Builder) (bool, error) {

--- a/configure/configure.go
+++ b/configure/configure.go
@@ -2,6 +2,8 @@ package configure
 
 import (
 	"bufio"
+	"fmt"
+	"log"
 	"os"
 
 	"github.com/cubicdaiya/nginx-build/command"
@@ -15,6 +17,7 @@ func Run() error {
 
 	f, err := os.Create("nginx-configure.log")
 	if err != nil {
+		log.Printf("[warn] could not create nginx-configure.log: %v", err)
 		return command.Run(args)
 	}
 	defer f.Close()
@@ -28,5 +31,9 @@ func Run() error {
 	cmd.Stdout = writer
 	defer writer.Flush()
 
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("configure failed: %w", err)
+	}
+
+	return nil
 }

--- a/module3rd/provide.go
+++ b/module3rd/provide.go
@@ -13,24 +13,34 @@ import (
 func Provide(m *Module3rd) error {
 	if len(m.Rev) > 0 {
 		dir := util.SaveCurrentDir()
-		os.Chdir(m.Name)
+		if err := os.Chdir(m.Name); err != nil {
+			return fmt.Errorf("chdir to %s failed: %w", m.Name, err)
+		}
 		if err := switchRev(m.Form, m.Rev); err != nil {
 			return fmt.Errorf("%s (%s checkout %s): %s", m.Name, m.Form, m.Rev, err.Error())
 		}
-		os.Chdir(dir)
+		if err := os.Chdir(dir); err != nil {
+			return fmt.Errorf("return to dir %s failed: %w", dir, err)
+		}
 	}
 
 	if len(m.Shprov) > 0 {
 		dir := util.SaveCurrentDir()
 		if len(m.ShprovDir) > 0 {
-			os.Chdir(m.Name + "/" + m.ShprovDir)
+			if err := os.Chdir(m.Name + "/" + m.ShprovDir); err != nil {
+				return fmt.Errorf("chdir to %s/%s failed: %w", m.Name, m.ShprovDir, err)
+			}
 		} else {
-			os.Chdir(m.Name)
+			if err := os.Chdir(m.Name); err != nil {
+				return fmt.Errorf("chdir to %s failed: %w", m.Name, err)
+			}
 		}
 		if err := provideShell(m.Shprov); err != nil {
 			return fmt.Errorf("%s's shprov(%s): %s", m.Name, m.Shprov, err.Error())
 		}
-		os.Chdir(dir)
+		if err := os.Chdir(dir); err != nil {
+			return fmt.Errorf("return to dir %s failed: %w", dir, err)
+		}
 	}
 
 	return nil

--- a/nginx-build.go
+++ b/nginx-build.go
@@ -347,7 +347,9 @@ func main() {
 	}
 
 	// cd workDir/nginx-${version}
-	os.Chdir(nginxBuilder.SourcePath())
+	if err := os.Chdir(nginxBuilder.SourcePath()); err != nil {
+		log.Fatalf("failed to change directory: %v", err)
+	}
 
 	var dependencies []builder.StaticLibrary
 	if *pcreStatic {


### PR DESCRIPTION
## Summary
- add warnings when log files can't be created
- return wrapped errors for build and configure failures
- check `os.Chdir` results and return errors in 3rd party module provider
- fail early when unable to change to nginx source directory

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684d11326d548326b2856aeb1159f642