### PR TITLE
Fix typo in nginx-build.go comment

### DIFF
--- a/nginx-build.go
+++ b/nginx-build.go
@@ -277,7 +277,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// remove nginx source code applyed patch
+	// remove nginx source code applied patch
 	if *patchPath != "" && util.FileExists(nginxBuilder.SourcePath()) {
 		err := os.RemoveAll(nginxBuilder.SourcePath())
 		if err != nil {


### PR DESCRIPTION
## Summary
- fix a typo in a comment of `nginx-build.go`

## Testing
- `go fmt ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684d128044648326931782fb58e1fdfe